### PR TITLE
Ignoring invalid lines instead of discard the whole file

### DIFF
--- a/src/main/java/org/sonar/plugins/jacoco/ReportImporter.java
+++ b/src/main/java/org/sonar/plugins/jacoco/ReportImporter.java
@@ -22,8 +22,11 @@ package org.sonar.plugins.jacoco;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.batch.sensor.coverage.NewCoverage;
+import org.sonar.api.utils.log.Logger;
+import org.sonar.api.utils.log.Loggers;
 
 public class ReportImporter {
+  private static final Logger LOG = Loggers.get(ReportImporter.class);
   private final SensorContext ctx;
 
   public ReportImporter(SensorContext ctx) {
@@ -41,9 +44,14 @@ public class ReportImporter {
         newCoverage.conditions(line.number(), branches, line.coveredBranches());
         conditions = true;
       }
+      if (line.number() > inputFile.lines()) {
+          LOG.warn("No matching line in source");
+          break;
+      }
       if (conditions || line.coveredInstrs() > 0 || line.missedInstrs() > 0) {
         newCoverage.lineHits(line.number(), line.coveredInstrs() > 0 ? 1 : 0);
       }
+
     }
 
     newCoverage.save();

--- a/src/test/java/org/sonar/plugins/jacoco/ReportImporterTest.java
+++ b/src/test/java/org/sonar/plugins/jacoco/ReportImporterTest.java
@@ -53,6 +53,7 @@ public class ReportImporterTest {
     sourceFile.lines().add(new XmlReportParser.Line(1, 0, 0, 1, 1));
     sourceFile.lines().add(new XmlReportParser.Line(2, 1, 2, 0, 0));
     sourceFile.lines().add(new XmlReportParser.Line(3, 2, 0, 0, 0));
+    sourceFile.lines().add(new XmlReportParser.Line(11, 0, 3, 0, 0));
 
     importer.importCoverage(sourceFile, inputFile);
 


### PR DESCRIPTION
This is related to: 
https://community.sonarsource.com/t/sonar-kotlin-coverage-fails-due-to-line-is-out-of-range-errors
and 
https://community.sonarsource.com/t/lines-out-of-range-in-kotlin-code/3167
Instead of discarding the whole file, the proposed fix just ignores the lines that do not appear on the `.kt` files. A similar approach is done in the sonar kotlin plugin (detekt) https://github.com/arturbosch/sonar-kotlin/blob/a45717e525639d0b075dacec504dd9a2362ead15/src/main/kotlin/io/gitlab/arturbosch/detekt/sonar/jacoco/KotlinJacocoReportAnalyzer.kt#L192

The real issue seems to be the kotlin compiler but looks like this wont be fixed --> https://youtrack.jetbrains.com/issue/KT-9766