### PR TITLE
Fix coverage for files in default package

### DIFF
--- a/src/main/java/org/sonar/plugins/jacoco/FileLocator.java
+++ b/src/main/java/org/sonar/plugins/jacoco/FileLocator.java
@@ -41,7 +41,7 @@ public class FileLocator {
 
   @CheckForNull
   public InputFile getInputFile(String packagePath, String fileName) {
-    String filePath = packagePath + "/" + fileName;
+    String filePath = packagePath.isEmpty() ? fileName : packagePath + "/" + fileName;
     String[] path = filePath.split("/");
     return tree.getFileWithSuffix(path);
   }

--- a/src/test/java/org/sonar/plugins/jacoco/FileLocatorTest.java
+++ b/src/test/java/org/sonar/plugins/jacoco/FileLocatorTest.java
@@ -36,6 +36,13 @@ public class FileLocatorTest {
   }
 
   @Test
+  public void should_match_default_package() {
+    InputFile inputFile = new TestInputFileBuilder("module1", "src/main/java/File.java").build();
+    FileLocator locator = new FileLocator(Collections.singleton(inputFile));
+    assertThat(locator.getInputFile("", "File.java")).isEqualTo(inputFile);
+  }
+
+  @Test
   public void should_not_match() {
     InputFile inputFile = new TestInputFileBuilder("module1", "src/main/java/org/sonar/test/File.java").build();
     FileLocator locator = new FileLocator(Collections.singleton(inputFile));


### PR DESCRIPTION
After migrating from JaCoCo binary report format to XML we discovered that coverage for files in default package was no longer recorded. The coverage information in XML is present with an empty package name, but `getInputFile` was returning `null` for those files.