### PR TITLE
Show defaults in SonarQube Frontend

### DIFF
--- a/src/main/java/org/sonar/plugins/jacoco/JacocoPlugin.java
+++ b/src/main/java/org/sonar/plugins/jacoco/JacocoPlugin.java
@@ -30,6 +30,7 @@ public class JacocoPlugin implements Plugin {
       .multiValues(true)
       .category("JaCoCo")
       .description("Paths to JaCoCo XML coverage report files. Each path can be either absolute or relative to the project base directory.")
+      .defaultValue(String.join(",", ReportPathsProvider.DEFAULT_PATHS))
       .build());
   }
 }

--- a/src/main/java/org/sonar/plugins/jacoco/ReportPathsProvider.java
+++ b/src/main/java/org/sonar/plugins/jacoco/ReportPathsProvider.java
@@ -29,8 +29,8 @@ import java.util.stream.Stream;
 import org.sonar.api.batch.sensor.SensorContext;
 
 class ReportPathsProvider {
-  private static final String[] DEFAULT_PATHS = {"target/site/jacoco/jacoco.xml", "build/reports/jacoco/test/jacocoTestReport.xml"};
-  static final String REPORT_PATHS_PROPERTY_KEY = "sonar.coverage.jacoco.xmlReportPaths";
+  public static final String[] DEFAULT_PATHS = {"target/site/jacoco/jacoco.xml", "build/reports/jacoco/test/jacocoTestReport.xml"};
+  public static final String REPORT_PATHS_PROPERTY_KEY = "sonar.coverage.jacoco.xmlReportPaths";
 
   private final SensorContext context;
 


### PR DESCRIPTION
Is a bit confusing if this plugin works with default settings, but the default settings are not shown in the SonarQube frontend.
These few lines fix this behavior.
