### PR TITLE
Fix Unit tests on Windows

### DIFF
--- a/src/test/java/org/sonar/plugins/jacoco/ReportPathsProviderTest.java
+++ b/src/test/java/org/sonar/plugins/jacoco/ReportPathsProviderTest.java
@@ -73,7 +73,7 @@ class ReportPathsProviderTest {
     settings.setProperty(ReportPathsProvider.REPORT_PATHS_PROPERTY_KEY, "/my/path");
     tester.setSettings(settings);
 
-    assertThat(provider.getPaths()).containsOnly(Paths.get("/my/path"));
+    assertThat(provider.getPaths()).containsOnly(baseDir.resolve("/my/path"));
   }
 
   @Test


### PR DESCRIPTION
The absolute path on windows can be something like `"C:/my/path"`