### PR TITLE
JACOCO-11 Set reportPaths property on project level

### DIFF
--- a/src/main/java/org/sonar/plugins/jacoco/JacocoPlugin.java
+++ b/src/main/java/org/sonar/plugins/jacoco/JacocoPlugin.java
@@ -21,12 +21,14 @@ package org.sonar.plugins.jacoco;
 
 import org.sonar.api.Plugin;
 import org.sonar.api.config.PropertyDefinition;
+import org.sonar.api.resources.Qualifiers;
 
 public class JacocoPlugin implements Plugin {
   @Override
   public void define(Context context) {
     context.addExtension(JacocoSensor.class);
     context.addExtension(PropertyDefinition.builder(ReportPathsProvider.REPORT_PATHS_PROPERTY_KEY)
+      .onQualifiers(Qualifiers.PROJECT)
       .multiValues(true)
       .category("JaCoCo")
       .description("Paths to JaCoCo XML coverage report files. Each path can be either absolute or relative to the project base directory.")

--- a/src/test/java/org/sonar/plugins/jacoco/JacocoPluginTest.java
+++ b/src/test/java/org/sonar/plugins/jacoco/JacocoPluginTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.sonar.api.Plugin;
 import org.sonar.api.config.PropertyDefinition;
+import org.sonar.api.resources.Qualifiers;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -46,5 +47,6 @@ class JacocoPluginTest {
     PropertyDefinition propertyDefinition = (PropertyDefinition) arg.getAllValues().get(1);
     assertThat(propertyDefinition.key()).isEqualTo("sonar.coverage.jacoco.xmlReportPaths");
     assertThat(propertyDefinition.category()).isEqualTo("JaCoCo");
+    assertThat(propertyDefinition.qualifiers()).containsOnly(Qualifiers.PROJECT);
   }
 }


### PR DESCRIPTION
Also manually tested. With version 1.0.2, it is not possible to update the property at project level in SQ UI, once updated with this snapshot, I can change it from there.