### PR TITLE
JACOCO-16 Allow kotlin style directories to be reported for coverage

### DIFF
--- a/src/main/java/org/sonar/plugins/jacoco/JacocoSensor.java
+++ b/src/main/java/org/sonar/plugins/jacoco/JacocoSensor.java
@@ -69,8 +69,27 @@ public class JacocoSensor implements Sensor {
   void importReport(XmlReportParser reportParser, FileLocator locator, ReportImporter importer) {
     List<XmlReportParser.SourceFile> sourceFiles = reportParser.parse();
 
+    boolean kotlinPackageScheme = false;
+    if (sourceFiles.size() != 0) {
+      XmlReportParser.SourceFile sourceFile = sourceFiles.get(0);
+
+      String packageName = sourceFile.packageName();
+      String fileName = sourceFile.name();
+
+      InputFile inputFile = locator.getInputFile(packageName, fileName);
+      if (inputFile == null) {
+        inputFile = locator.getInputFile(packageName.replace(sourceFile.rootPackageName() + "/", ""), fileName);
+        kotlinPackageScheme = inputFile != null;
+      }
+    }
+
     for (XmlReportParser.SourceFile sourceFile : sourceFiles) {
-      InputFile inputFile = locator.getInputFile(sourceFile.packageName(), sourceFile.name());
+      String packagePath = sourceFile.packageName();
+      if (kotlinPackageScheme) {
+        packagePath = packagePath.replace(sourceFile.rootPackageName() + "/", "");
+      }
+
+      InputFile inputFile = locator.getInputFile(packagePath, sourceFile.name());
       if (inputFile == null) {
         continue;
       }

--- a/src/test/java/org/sonar/plugins/jacoco/JacocoSensorTest.java
+++ b/src/test/java/org/sonar/plugins/jacoco/JacocoSensorTest.java
@@ -83,6 +83,24 @@ class JacocoSensorTest {
   }
 
   @Test
+  void import_coverage_on_kotlin_style_package() {
+    FileLocator locator = mock(FileLocator.class);
+    ReportImporter importer = mock(ReportImporter.class);
+    XmlReportParser parser = mock(XmlReportParser.class);
+    InputFile inputFile = mock(InputFile.class);
+
+    XmlReportParser.SourceFile sourceFile = new XmlReportParser.SourceFile("io/foo/bar/baz", "File.java", new XmlReportParser.RootPackage("io/foo/bar"));
+    sourceFile.lines().add(new XmlReportParser.Line(1, 0, 1, 0, 0));
+
+    when(parser.parse()).thenReturn(Collections.singletonList(sourceFile));
+    when(locator.getInputFile("baz", "File.java")).thenReturn(inputFile);
+
+    sensor.importReport(parser, locator, importer);
+
+    verify(importer).importCoverage(sourceFile, inputFile);
+  }
+
+  @Test
   void do_nothing_if_no_path() {
     ReportPathsProvider reportPathsProvider = mock(ReportPathsProvider.class);
     FileLocator locator = mock(FileLocator.class);
@@ -148,7 +166,7 @@ class JacocoSensorTest {
     FileLocator locator = mock(FileLocator.class);
     ReportImporter importer = mock(ReportImporter.class);
     XmlReportParser parser = mock(XmlReportParser.class);
-    XmlReportParser.SourceFile sourceFile = mock(XmlReportParser.SourceFile.class);
+    XmlReportParser.SourceFile sourceFile = new XmlReportParser.SourceFile("", "", new XmlReportParser.RootPackage());
 
     when(parser.parse()).thenReturn(Collections.singletonList(sourceFile));
     sensor.importReport(parser, locator, importer);

--- a/src/test/java/org/sonar/plugins/jacoco/ReportPathsProviderTest.java
+++ b/src/test/java/org/sonar/plugins/jacoco/ReportPathsProviderTest.java
@@ -98,18 +98,19 @@ class ReportPathsProviderTest {
     Path reportPath = baseDir.resolve(Paths.get("target", "custom", "jacoco.xml"));
     Files.createDirectories(reportPath.getParent());
     Files.createFile(reportPath);
+    Path realReportPath = reportPath.toRealPath();
 
     settings.setProperty(ReportPathsProvider.REPORT_PATHS_PROPERTY_KEY, "target/custom/*.xml");
-    assertThat(provider.getPaths()).containsOnly(reportPath);
+    assertThat(provider.getPaths()).containsOnly(realReportPath);
 
     settings.setProperty(ReportPathsProvider.REPORT_PATHS_PROPERTY_KEY, "target/**/ja*.xml");
-    assertThat(provider.getPaths()).containsOnly(reportPath);
+    assertThat(provider.getPaths()).containsOnly(realReportPath);
 
     settings.setProperty(ReportPathsProvider.REPORT_PATHS_PROPERTY_KEY, "target\\**\\ja*.xml");
-    assertThat(provider.getPaths()).containsOnly(reportPath);
+    assertThat(provider.getPaths()).containsOnly(realReportPath);
 
     settings.setProperty(ReportPathsProvider.REPORT_PATHS_PROPERTY_KEY, "**/*.xml");
-    assertThat(provider.getPaths()).containsOnly(reportPath);
+    assertThat(provider.getPaths()).containsOnly(realReportPath);
     assertThat(logTester.logs()).isEmpty();
 
     settings.setProperty(ReportPathsProvider.REPORT_PATHS_PROPERTY_KEY, "target/**/unknown.xml");
@@ -124,16 +125,17 @@ class ReportPathsProviderTest {
     Path reportPath = baseDir.resolve(Paths.get("target", "custom", "jacoco.xml"));
     Files.createDirectories(reportPath.getParent());
     Files.createFile(reportPath);
+    Path realReportPath = reportPath.toRealPath();
 
     String unixLikeAbsoluteBaseDir = baseDir.toRealPath().toString().replace('\\', '/');
     String unixLikeAbsoluteXmlPattern = unixLikeAbsoluteBaseDir + "/**/*.xml";
     String windowsLikeAbsoluteXmlPattern = unixLikeAbsoluteXmlPattern.replace('/', '\\');
 
     settings.setProperty(ReportPathsProvider.REPORT_PATHS_PROPERTY_KEY, unixLikeAbsoluteXmlPattern);
-    assertThat(provider.getPaths()).containsOnly(reportPath);
+    assertThat(provider.getPaths()).containsOnly(realReportPath);
 
     settings.setProperty(ReportPathsProvider.REPORT_PATHS_PROPERTY_KEY, windowsLikeAbsoluteXmlPattern);
-    assertThat(provider.getPaths()).containsOnly(reportPath);
+    assertThat(provider.getPaths()).containsOnly(realReportPath);
     assertThat(logTester.logs()).isEmpty();
   }
 

--- a/src/test/java/org/sonar/plugins/jacoco/XmlReportParserTest.java
+++ b/src/test/java/org/sonar/plugins/jacoco/XmlReportParserTest.java
@@ -50,6 +50,16 @@ class XmlReportParserTest {
   }
 
   @Test
+  void should_parse_root_package_in_report() throws URISyntaxException {
+    Path sample = load("jacoco.xml");
+    XmlReportParser report = new XmlReportParser(sample);
+    List<XmlReportParser.SourceFile> sourceFiles = report.parse();
+
+    assertThat(sourceFiles).hasSize(36);
+    assertThat(sourceFiles.stream().allMatch(sf -> sf.rootPackageName().equals("org/sonarlint/cli"))).isTrue();
+  }
+
+  @Test
   void should_parse_all_attributes() throws URISyntaxException {
     Path sample = load("simple.xml");
     XmlReportParser report = new XmlReportParser(sample);


### PR DESCRIPTION
**Details**

Currently the jacoco coverage plugin does not take into account [kotlin-styled directory structure](https://kotlinlang.org/docs/reference/coding-conventions.html#directory-structure) where the package name and the filesystem need not match (the root package is omitted from the filesystem)
 
This fixes [JACOCO-16](https://jira.sonarsource.com/browse/JACOCO-16) and its connected [forum issue](https://community.sonarsource.com/t/sonar-coverage-jacoco-xmlreportpaths-not-reporting-coverage/25178/7)

**Tests**
Tests covering the functionality have been added. 

Additional tests were failing on OSX where the temp `/var` directory is symlinked to `/private/var` and as such the expectation needed to go through the same `path.toRealPath()` treatment.

