### PR TITLE
JACOCO-30 Upgrade orchestrator to version 5.5

### DIFF
--- a/its/build.gradle
+++ b/its/build.gradle
@@ -9,7 +9,8 @@ dependencies {
   testImplementation 'org.junit.jupiter:junit-jupiter-migrationsupport:5.6.2'
   testImplementation 'org.mockito:mockito-core:1.10.19'
   testImplementation 'org.assertj:assertj-core:3.10.0'
-  testImplementation 'org.sonarsource.orchestrator:sonar-orchestrator:3.40.0.183'
+  testImplementation 'org.sonarsource.orchestrator:sonar-orchestrator:5.5.0.2535'
+  testImplementation 'org.sonarsource.orchestrator:sonar-orchestrator-junit4:5.5.0.2535'
   testImplementation 'org.sonarsource.sonarqube:sonar-ws:6.7'
   testImplementation 'com.google.code.findbugs:jsr305:2.0.2'
 }

--- a/its/src/test/java/org/sonar/plugins/jacoco/its/JacocoTest.java
+++ b/its/src/test/java/org/sonar/plugins/jacoco/its/JacocoTest.java
@@ -1,7 +1,7 @@
 package org.sonar.plugins.jacoco.its;
 
-import com.sonar.orchestrator.Orchestrator;
-import com.sonar.orchestrator.OrchestratorBuilder;
+import com.sonar.orchestrator.junit4.OrchestratorRule;
+import com.sonar.orchestrator.junit4.OrchestratorRuleBuilder;
 import com.sonar.orchestrator.build.BuildResult;
 import com.sonar.orchestrator.build.MavenBuild;
 import com.sonar.orchestrator.build.SonarScanner;
@@ -41,7 +41,7 @@ public class JacocoTest {
   private static final String KOTLIN_FILE_KEY = "org.sonarsource.it.projects:kotlin-jacoco-project:src/main/kotlin/CoverMe.kt";
   private static final String FILE_WITHOUT_COVERAGE_KEY = "jacoco-test-project:src/main/java/org/sonarsource/test/CalcNoCoverage.java";
 
-  private static Orchestrator orchestrator;
+  private static OrchestratorRule orchestrator;
 
 
   @TempDir
@@ -50,7 +50,7 @@ public class JacocoTest {
   @BeforeAll
   static void beforeAll() {
     String defaultRuntimeVersion = "true".equals(System.getenv("SONARSOURCE_QA")) ? null : "LATEST_RELEASE";
-    OrchestratorBuilder builder = Orchestrator.builderEnv()
+    OrchestratorRuleBuilder builder = OrchestratorRule.builderEnv()
       .useDefaultAdminCredentialsForBuilds(true)
       .setOrchestratorProperty("orchestrator.workspaceDir", "build")
       .setSonarVersion(System.getProperty("sonar.runtimeVersion", defaultRuntimeVersion));


### PR DESCRIPTION
[JACOCO-30](https://sonarsource.atlassian.net/browse/JACOCO-30)


This is to avoid polluting telemetry data with integration tests.


[JACOCO-30]: https://sonarsource.atlassian.net/browse/JACOCO-30?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ