### PR TITLE
JACOCO-113 Set up orchestrator cache

### DIFF
--- a/.github/actions/orchestrator-cache/action.yml
+++ b/.github/actions/orchestrator-cache/action.yml
@@ -1,0 +1,32 @@
+name: Setup Orchestrator Cache
+description: Sets up orchestrator cache
+
+inputs:
+  sq-version:
+    description: 'SonarQube version. If DEV, cache will be disabled.'
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Set Orchestrator Cache Variables
+      shell: bash
+      run: |
+        # year-week
+        CACHE_KEY=$(date +'%Y-%U')
+        echo "ORCHESTRATOR_CACHE_KEY=$CACHE_KEY" >> $GITHUB_ENV
+        echo "ORCHESTRATOR_HOME=${{ github.workspace }}/orchestrator" >> $GITHUB_ENV
+
+    - name: Cache Orchestrator
+      if: inputs.sq-version != 'DEV'
+      uses: SonarSource/gh-action_cache@v1
+      with:
+        path: ${{ env.ORCHESTRATOR_HOME }}
+        key: orchestrator-${{ inputs.sq-version }}-${{ env.ORCHESTRATOR_CACHE_KEY }}-${{ github.run_id }}
+        restore-keys: orchestrator-${{ inputs.sq-version }}-${{ env.ORCHESTRATOR_CACHE_KEY }}-
+
+    - name: Setup Orchestrator Home Directory
+      shell: bash
+      run: |
+        mkdir -p "$ORCHESTRATOR_HOME"
+        ls -lRh "$ORCHESTRATOR_HOME"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,7 @@ jobs:
       contents: write  # Required for repository access and tagging
     env:
       BUILD_NUMBER: ${{ needs.build.outputs.build-number }}
+      SQ_VERSION: 'LATEST_RELEASE[2025.4]'
     steps:
       - name: Config Git
         run: git config --global core.autocrlf input
@@ -70,10 +71,16 @@ jobs:
         uses: SonarSource/ci-github-actions/config-gradle@v1
         with:
           artifactory-reader-role: private-reader
+      - name: Orchestrator Cache
+        uses: ./.github/actions/orchestrator-cache
+        with:
+          sq-version: ${{ env.SQ_VERSION }}
       - name: Build
         env:
           GITHUB_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).GITHUB_TOKEN }}
-        run: ./gradlew -D"sonar.runtimeVersion"="LATEST_RELEASE[2025.4]" -DbuildNumber=$BUILD_NUMBER --no-daemon --console plain --info --stacktrace build test -PintegrationTests=true
+        shell: bash
+        run: |
+          ./gradlew "-Dsonar.runtimeVersion=$SQ_VERSION" -DbuildNumber=$BUILD_NUMBER --no-daemon --console plain --info --stacktrace build test -PintegrationTests=true
 
   qa:
     needs: [build]
@@ -85,11 +92,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        item:
-        - { sq-version: "LATEST_RELEASE[2025.1]" }
-        - { sq-version: "LATEST_RELEASE[2025.4]" }
-        - { sq-version: "DEV" }
-    name: "QA Tests - SQ : ${{ matrix.item.sq-version }}"
+        sq-version:
+          - "LATEST_RELEASE[2025.1]"
+          - "LATEST_RELEASE[2025.4]"
+          - "DEV"
+        is_nightly:
+          - ${{ github.event_name == 'schedule' }}
+        exclude:
+          # DEV is tested only in nightly to reduce Repox usage
+          - sq-version: "DEV"
+            is_nightly: false
+    name: "QA Tests - SQ : ${{ matrix.sq-version }}"
     env:
       BUILD_NUMBER: ${{ needs.build.outputs.build-number }}
     steps:
@@ -112,10 +125,14 @@ jobs:
         uses: SonarSource/ci-github-actions/config-gradle@v1
         with:
           artifactory-reader-role: private-reader
+      - name: Orchestrator Cache
+        uses: ./.github/actions/orchestrator-cache
+        with:
+          sq-version: ${{ matrix.sq-version }}
       - name: Run QA Tests
         shell: bash
         env:
-          SQ_VERSION: ${{ matrix.item.sq-version }}
+          SQ_VERSION: ${{ matrix.sq-version }}
           GITHUB_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).GITHUB_TOKEN }}
         run: >-
           ./gradlew -DbuildNumber=$BUILD_NUMBER

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,7 +101,7 @@ jobs:
         exclude:
           # DEV is tested only in nightly to reduce Repox usage
           - sq-version: "DEV"
-            is_nightly: true
+            is_nightly: false
     name: "QA Tests - SQ : ${{ matrix.sq-version }}"
     env:
       BUILD_NUMBER: ${{ needs.build.outputs.build-number }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,7 +101,7 @@ jobs:
         exclude:
           # DEV is tested only in nightly to reduce Repox usage
           - sq-version: "DEV"
-            is_nightly: false
+            is_nightly: true
     name: "QA Tests - SQ : ${{ matrix.sq-version }}"
     env:
       BUILD_NUMBER: ${{ needs.build.outputs.build-number }}

--- a/.github/workflows/cleanup-cache.yml
+++ b/.github/workflows/cleanup-cache.yml
@@ -1,0 +1,33 @@
+name: Cleanup S3 Cache
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch name (e.g., 'feature/my-branch'). Leave empty to list all entries."
+        required: false
+        type: string
+        default: ""
+      key:
+        description: "Cache key prefix (e.g., 'sccache-Linux-')"
+        required: false
+        type: string
+        default: ""
+      dry-run:
+        description: "Preview deletions without executing them"
+        required: false
+        type: boolean
+        default: true
+
+jobs:
+  cleanup:
+    runs-on: sonar-xs-public
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: SonarSource/gh-action_cache/cleanup@v1
+        with:
+          branch: ${{ inputs.branch }}
+          key: ${{ inputs.key }}
+          dry-run: ${{ inputs.dry-run }}


### PR DESCRIPTION
* Create `.github/actions/orchestrator-cache/action.yml` (copied from sonar-java) and use it in build.
* Add workflow to manage S3 cache (`.github/workflows/cleanup-cache.yml`)
* Also disable testing against `DEV` sq outside nightly. (Tested in https://github.com/SonarSource/sonar-jacoco/actions/runs/24235947372 by inverting the condition).
* Small cleanup: use Bash on windows for consistency and to avoid suprises in PowerShell.