### PR TITLE
PREQ-6119 Fix SCA Check by setting correct project key

### DIFF
--- a/.github/repo-metadata.yaml
+++ b/.github/repo-metadata.yaml
@@ -1,0 +1,2 @@
+check-sca:
+  project-key: org.sonarsource.jacoco:sonar-jacoco


### PR DESCRIPTION
## Summary
- The `verify-sca` check auto-detects the project key as `SonarSource_sonar-jacoco` but the actual SonarQube project uses the Maven-style key `org.sonarsource.jacoco:sonar-jacoco`
- Added `.github/repo-metadata.yaml` to explicitly set the project key per [ci-github-actions docs](https://github.com/SonarSource/ci-github-actions#manually-setting-the-project-key-for-the-check)

## Jira
[PREQ-6119](https://sonarsource.atlassian.net/browse/PREQ-6119)

## Test plan
- [ ] Verify the `verify-sca` check passes on this PR

[PREQ-6119]: https://sonarsource.atlassian.net/browse/PREQ-6119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ