### PR TITLE
JACOCO-128 Use squad Renovate preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,31 +1,14 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "local>SonarSource/core-languages-tooling-public:renovate-config"
+    "local>SonarSource/core-languages-tooling-public:sonar-jacoco"
   ],
-  "addLabels": [
-    "dependencies"
-  ],
-  "schedule": [
-    "before 4am on Monday"
-  ],
-  "rebaseWhen": "conflicted",
-  "minimumReleaseAgeBehaviour": "timestamp-required",
   "enabledManagers": [
     "gradle",
     "gradle-wrapper",
     "github-actions"
   ],
   "packageRules": [
-    {
-      "description": "Group Gradle updates",
-      "matchManagers": [
-        "gradle",
-        "gradle-wrapper"
-      ],
-      "groupName": "Gradle dependencies",
-      "groupSlug": "gradle-dependencies"
-    },
     {
       "matchManagers": [
         "github-actions"
@@ -73,8 +56,5 @@
       "groupSlug": "sonar-plugin-api",
       "prHeader": "**Before updating the plugin-api version, make sure to check the [compatibility matrix](https://github.com/SonarSource/sonar-plugin-api?tab=readme-ov-file#compatibility) and stick to the lowest denominator.**"
     }
-  ],
-  "reviewers": [
-    "team:quality-jvm-squad"
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "local>SonarSource/core-languages-tooling-public:sonar-jacoco"
+    "local>SonarSource/core-languages-tooling-public:renovate-config"
   ],
   "enabledManagers": [
     "gradle",

--- a/renovate.json
+++ b/renovate.json
@@ -1,18 +1,31 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>SonarSource/renovate-config:languages-team"
+    "local>SonarSource/core-languages-tooling-public:renovate-config"
+  ],
+  "addLabels": [
+    "dependencies"
   ],
   "schedule": [
     "before 4am on Monday"
   ],
   "rebaseWhen": "conflicted",
+  "minimumReleaseAgeBehaviour": "timestamp-required",
   "enabledManagers": [
     "gradle",
     "gradle-wrapper",
     "github-actions"
   ],
   "packageRules": [
+    {
+      "description": "Group Gradle updates",
+      "matchManagers": [
+        "gradle",
+        "gradle-wrapper"
+      ],
+      "groupName": "Gradle dependencies",
+      "groupSlug": "gradle-dependencies"
+    },
     {
       "matchManagers": [
         "github-actions"


### PR DESCRIPTION
## Summary
- switch this repository to the squad Renovate preset
- keep only repo-specific Renovate behavior in the repository

## Effective Delta After Merge
<!-- codex-effective-delta:start -->
- rebaseWhen: conflicted -> never
- minimumReleaseAgeBehaviour: timestamp-required -> timestamp-optional
- schedule: before 4am on Monday -> unset
- prCreation: not-pending -> immediate
- reviewers: team:quality-jvm-squad -> unset
- packageRules removed: {"matchManagers":["regex"],"versioning":"regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+).(?<build>\\d+)?$"}
- packageRules added: Don't group updates by default
- regexManagers: 1 -> 0
<!-- codex-effective-delta:end -->
