### PR TITLE
CLP-177 Switch Renovate preset to quality-corelang-squad

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "local>SonarSource/core-languages-tooling-public:renovate-config"
+    "github>SonarSource/renovate-config:quality-corelang-squad"
   ],
   "ignorePaths": [
     "its/src/test/resources/**"


### PR DESCRIPTION
Part of CLP-11.

This PR normalizes the Renovate config location to `.github/renovate.json` and switches the shared preset reference to `github>SonarSource/renovate-config:quality-corelang-squad` without changing effective Renovate behavior.

Expected current effective delta:
- none
