### PR TITLE
JACOCO-140 Fix quality gate

### DIFF
--- a/src/main/java/org/sonar/plugins/jacoco/ProjectFileLocator.java
+++ b/src/main/java/org/sonar/plugins/jacoco/ProjectFileLocator.java
@@ -52,9 +52,13 @@ public class ProjectFileLocator extends FileLocator {
   }
 
   @CheckForNull
-  private InputFile getInputFileForProject(String groupName, String filePath) {
-    // First, try to look up the file in the tree using the computed path
+  private InputFile getInputFileForProject(@Nullable String groupName, String filePath) {
     String[] pathSegments = filePath.split(FileLocator.SEPARATOR_REGEX);
+    // Without a group name we cannot disambiguate between sub-projects, so fall back to a group-agnostic lookup (same behavior as ModuleFileLocator).
+    if (groupName == null) {
+      return tree.getFileWithSuffix(pathSegments);
+    }
+    // First, try to look up the file in the tree using the computed path
     InputFile file = tree.getFileWithSuffix(groupName, pathSegments);
     if (file != null) {
       return file;

--- a/src/test/java/org/sonar/plugins/jacoco/FileLocatorTest.java
+++ b/src/test/java/org/sonar/plugins/jacoco/FileLocatorTest.java
@@ -214,4 +214,15 @@ class FileLocatorTest {
     assertThat(locator.getInputFile(null, "", "DoesNotExist.java")).isNull();
   }
 
+  @Test
+  void project_file_locator_should_not_fail_with_a_null_group_and_ambiguous_files() {
+    InputFile appFile = new TestInputFileBuilder("my-project", "app/src/main/java/File.java").build();
+    InputFile utilsFile = new TestInputFileBuilder("my-project", "utils/src/main/java/File.java").build();
+
+    ProjectFileLocator locator = new ProjectFileLocator(List.of(appFile, utilsFile), null, new ProjectCoverageContext());
+
+    // Should fall back to a group-agnostic lookup and return the first match, not blow up with an NPE
+    assertThat(locator.getInputFile(null, "", "File.java")).isEqualTo(appFile);
+  }
+
 }


### PR DESCRIPTION
----
## Summary by Gitar

- **Bug fixes:**
  - Modified `ProjectFileLocator` to handle null `groupName` values safely to prevent potential errors.
  - Added a fallback to group-agnostic lookup in `ProjectFileLocator` when the group name is unavailable.
- **Test updates:**
  - Added unit test in `FileLocatorTest` to verify that `ProjectFileLocator` handles ambiguous files without throwing exceptions.

<sub>This will update automatically on new commits.</sub>