### PR TITLE
JACOCO-119 Push coverage report warnings to SonarQube analysis

### DIFF
--- a/src/main/java/org/sonar/plugins/jacoco/JacocoAggregateSensor.java
+++ b/src/main/java/org/sonar/plugins/jacoco/JacocoAggregateSensor.java
@@ -29,6 +29,7 @@ import org.slf4j.LoggerFactory;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.batch.sensor.SensorDescriptor;
+import org.sonar.api.notifications.AnalysisWarnings;
 import org.sonar.api.scanner.sensor.ProjectSensor;
 
 import static org.sonar.plugins.jacoco.SensorUtils.importReports;
@@ -36,9 +37,11 @@ import static org.sonar.plugins.jacoco.SensorUtils.importReports;
 public class JacocoAggregateSensor implements ProjectSensor {
   private static final Logger LOG = LoggerFactory.getLogger(JacocoAggregateSensor.class);
   private final ProjectCoverageContext projectCoverageContext;
+  private final AnalysisWarnings analysisWarnings;
 
-  public JacocoAggregateSensor(ProjectCoverageContext projectCoverageContext) {
+  public JacocoAggregateSensor(ProjectCoverageContext projectCoverageContext, AnalysisWarnings analysisWarnings) {
     this.projectCoverageContext = projectCoverageContext;
+    this.analysisWarnings = analysisWarnings;
   }
 
   @Override
@@ -49,7 +52,7 @@ public class JacocoAggregateSensor implements ProjectSensor {
   @Override
   public void execute(SensorContext context) {
     this.projectCoverageContext.setProjectBaseDir(Paths.get(context.config().get("sonar.projectBaseDir").get()));
-    Set<Path> reportPaths = new ReportPathsProvider(context).getAggregateReportPaths();
+    Set<Path> reportPaths = new ReportPathsProvider(context, analysisWarnings).getAggregateReportPaths();
     if (reportPaths.isEmpty()) {
       LOG.debug("No aggregate XML report found. No coverage coverage information will be added at project level.");
       return;
@@ -59,6 +62,6 @@ public class JacocoAggregateSensor implements ProjectSensor {
     FileLocator locator = new ProjectFileLocator(inputFiles, new KotlinFileLocator(kotlinInputFileStream), projectCoverageContext);
     ReportImporter importer = new ReportImporter(context);
 
-    importReports(reportPaths, locator, importer, LOG);
+    importReports(reportPaths, locator, importer, LOG, analysisWarnings);
   }
 }

--- a/src/main/java/org/sonar/plugins/jacoco/JacocoSensor.java
+++ b/src/main/java/org/sonar/plugins/jacoco/JacocoSensor.java
@@ -29,6 +29,7 @@ import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.sensor.Sensor;
 import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.batch.sensor.SensorDescriptor;
+import org.sonar.api.notifications.AnalysisWarnings;
 
 import static org.sonar.plugins.jacoco.SensorUtils.importReports;
 
@@ -36,9 +37,11 @@ public class JacocoSensor implements Sensor {
   private static final Logger LOG = LoggerFactory.getLogger(JacocoSensor.class);
 
   private final ProjectCoverageContext projectCoverageContext;
+  private final AnalysisWarnings analysisWarnings;
 
-  public JacocoSensor(ProjectCoverageContext projectCoverageContext) {
+  public JacocoSensor(ProjectCoverageContext projectCoverageContext, AnalysisWarnings analysisWarnings) {
     this.projectCoverageContext = projectCoverageContext;
+    this.analysisWarnings = analysisWarnings;
   }
 
   @Override
@@ -49,7 +52,7 @@ public class JacocoSensor implements Sensor {
   @Override
   public void execute(SensorContext context) {
     recordModuleCoverageContext(context);
-    Collection<Path> reportPaths = new ReportPathsProvider(context).getPaths();
+    Collection<Path> reportPaths = new ReportPathsProvider(context, analysisWarnings).getPaths();
     if (reportPaths.isEmpty()) {
       LOG.info("No report imported, no coverage information will be imported by JaCoCo XML Report Importer");
       return;
@@ -59,7 +62,7 @@ public class JacocoSensor implements Sensor {
     ModuleFileLocator locator = new ModuleFileLocator(inputFiles, new KotlinFileLocator(kotlinInputFileStream));
     ReportImporter importer = new ReportImporter(context);
 
-    importReports(reportPaths, locator, importer, LOG);
+    importReports(reportPaths, locator, importer, LOG, analysisWarnings);
   }
 
   private void recordModuleCoverageContext(SensorContext sensorContext) {

--- a/src/main/java/org/sonar/plugins/jacoco/ReportPathsProvider.java
+++ b/src/main/java/org/sonar/plugins/jacoco/ReportPathsProvider.java
@@ -29,6 +29,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.sonar.api.batch.sensor.SensorContext;
+import org.sonar.api.notifications.AnalysisWarnings;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
 
@@ -44,9 +45,11 @@ class ReportPathsProvider {
   static final String REPORT_PATHS_PROPERTY_KEY = "sonar.coverage.jacoco.xmlReportPaths";
 
   private final SensorContext context;
+  private final AnalysisWarnings analysisWarnings;
 
-  ReportPathsProvider(SensorContext context) {
+  ReportPathsProvider(SensorContext context, AnalysisWarnings analysisWarnings) {
     this.context = context;
+    this.analysisWarnings = analysisWarnings;
   }
 
   Collection<Path> getPaths() {
@@ -71,8 +74,10 @@ class ReportPathsProvider {
       return reportPaths;
     } else {
       if (!patternPathList.isEmpty()) {
-        LOG.warn("No coverage report can be found with sonar.coverage.jacoco.xmlReportPaths='{}'. Using default locations: {}",
+        String message = String.format("No coverage report can be found with sonar.coverage.jacoco.xmlReportPaths='%s'. Using default locations: %s",
           String.join(",", patternPathList), String.join(",", DEFAULT_PATHS));
+        LOG.warn(message);
+        analysisWarnings.addUnique(message);
       } else {
         LOG.info("'sonar.coverage.jacoco.xmlReportPaths' is not defined. Using default locations: {}", String.join(",", DEFAULT_PATHS));
       }
@@ -98,7 +103,9 @@ class ReportPathsProvider {
     for (String reportPathPattern : reportPathsParam) {
       List<Path> scanned = WildcardPatternFileScanner.scan(context.fileSystem().baseDir().toPath(), reportPathPattern);
       if (scanned.isEmpty()) {
-        LOG.warn(String.format("No coverage report found for pattern: '%s'", reportPathPattern));
+        String message = String.format("No coverage report found for pattern: '%s'", reportPathPattern);
+        LOG.warn(message);
+        analysisWarnings.addUnique(message);
       } else {
         reportPaths.addAll(scanned);
       }

--- a/src/main/java/org/sonar/plugins/jacoco/SensorUtils.java
+++ b/src/main/java/org/sonar/plugins/jacoco/SensorUtils.java
@@ -24,13 +24,14 @@ import java.util.Collection;
 import java.util.List;
 import org.slf4j.Logger;
 import org.sonar.api.batch.fs.InputFile;
+import org.sonar.api.notifications.AnalysisWarnings;
 
 class SensorUtils {
   private SensorUtils() {
     /* This class should not be instantiated */
   }
 
-  static void importReports(Collection<Path> reportPaths, FileLocator locator, ReportImporter importer, Logger logger) {
+  static void importReports(Collection<Path> reportPaths, FileLocator locator, ReportImporter importer, Logger logger, AnalysisWarnings analysisWarnings) {
     logger.info("Importing {} report(s). Turn your logs in debug mode in order to see the exhaustive list.", reportPaths.size());
 
     for (Path reportPath : reportPaths) {
@@ -38,7 +39,9 @@ class SensorUtils {
       try {
         SensorUtils.importReport(new XmlReportParser(reportPath), locator, importer, logger);
       } catch (Exception e) {
-        logger.error("Coverage report '{}' could not be read/imported. Error: {}: {}", reportPath, e.getClass().getName(), e.getMessage());
+        String message = String.format("Coverage report '%s' could not be read/imported. Error: %s: %s", reportPath, e.getClass().getName(), e.getMessage());
+        logger.error(message);
+        analysisWarnings.addUnique(message);
       }
     }
   }

--- a/src/test/java/org/sonar/plugins/jacoco/JacocoAggregateSensorTest.java
+++ b/src/test/java/org/sonar/plugins/jacoco/JacocoAggregateSensorTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.event.Level;
 import org.sonar.api.batch.sensor.SensorDescriptor;
 import org.sonar.api.batch.sensor.internal.SensorContextTester;
+import org.sonar.api.notifications.AnalysisWarnings;
 import org.sonar.api.testfixtures.log.LogTesterJUnit5;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -44,9 +45,11 @@ class JacocoAggregateSensorTest {
   public LogTesterJUnit5 logTester = new LogTesterJUnit5();
 
   private SensorContextTester context;
+  private AnalysisWarnings analysisWarnings;
 
   @BeforeEach
   void setup() {
+    analysisWarnings = mock(AnalysisWarnings.class);
     context = spy(SensorContextTester.create(basedir));
     context.settings().clear();
     context.settings().setProperty("sonar.projectBaseDir", basedir.toString());
@@ -56,14 +59,14 @@ class JacocoAggregateSensorTest {
   @Test
   void description_name_is_as_expected() {
     SensorDescriptor descriptor = mock(SensorDescriptor.class);
-    var sensor = new JacocoAggregateSensor(new ProjectCoverageContext());
+    var sensor = new JacocoAggregateSensor(new ProjectCoverageContext(), analysisWarnings);
     sensor.describe(descriptor);
     verify(descriptor).name("JaCoCo Aggregate XML Report Importer");
   }
 
   @Test
   void log_missing_report_and_return_early_when_missing_analysis_parameter() {
-    var sensor = new JacocoAggregateSensor(new ProjectCoverageContext());
+    var sensor = new JacocoAggregateSensor(new ProjectCoverageContext(), analysisWarnings);
     sensor.execute(context);
 
     assertThat(logTester.logs(Level.DEBUG)).containsOnly(NO_REPORT_TO_IMPORT_LOG_MESSAGE);
@@ -74,7 +77,7 @@ class JacocoAggregateSensorTest {
     context.settings()
             .setProperty(ReportPathsProvider.AGGREGATE_REPORT_PATHS_PROPERTY_KEY, "non-existing-report.xml");
 
-    var sensor = new JacocoAggregateSensor(new ProjectCoverageContext());
+    var sensor = new JacocoAggregateSensor(new ProjectCoverageContext(), analysisWarnings);
     sensor.execute(context);
 
     assertThat(logTester.logs(Level.DEBUG)).
@@ -82,6 +85,7 @@ class JacocoAggregateSensorTest {
     assertThat(logTester.logs(Level.WARN))
             .contains("No coverage report found for pattern: 'non-existing-report.xml'");
     assertThat(logTester.logs(Level.INFO)).isEmpty();
+    verify(analysisWarnings).addUnique("No coverage report found for pattern: 'non-existing-report.xml'");
     verify(context, times(1)).addTelemetryProperty(TelemetryProperties.AGGREGATE_REPORT_PATH_PROPERTY_KEY_IS_SET, "true");
   }
 
@@ -92,7 +96,7 @@ class JacocoAggregateSensorTest {
     context.settings()
             .setProperty(ReportPathsProvider.AGGREGATE_REPORT_PATHS_PROPERTY_KEY, aggregateReport.toAbsolutePath().toString());
 
-    var sensor = new JacocoAggregateSensor(new ProjectCoverageContext());
+    var sensor = new JacocoAggregateSensor(new ProjectCoverageContext(), analysisWarnings);
     sensor.execute(context);
     assertThat(logTester.logs(Level.DEBUG)).doesNotContain(NO_REPORT_TO_IMPORT_LOG_MESSAGE);
     assertThat(logTester.logs(Level.INFO)).containsOnly(
@@ -107,7 +111,7 @@ class JacocoAggregateSensorTest {
     context.settings()
             .setProperty(ReportPathsProvider.AGGREGATE_REPORT_PATHS_PROPERTY_KEY, singModuleReport.toAbsolutePath().toString());
 
-    var sensor = new JacocoAggregateSensor(new ProjectCoverageContext());
+    var sensor = new JacocoAggregateSensor(new ProjectCoverageContext(), analysisWarnings);
     sensor.execute(context);
     assertThat(logTester.logs(Level.DEBUG)).doesNotContain(NO_REPORT_TO_IMPORT_LOG_MESSAGE);
     assertThat(logTester.logs(Level.DEBUG)).contains("Reading report '" + singModuleReport.toAbsolutePath() + "'");

--- a/src/test/java/org/sonar/plugins/jacoco/JacocoSensorTest.java
+++ b/src/test/java/org/sonar/plugins/jacoco/JacocoSensorTest.java
@@ -37,10 +37,12 @@ import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
 import org.sonar.api.batch.sensor.SensorDescriptor;
 import org.sonar.api.batch.sensor.internal.SensorContextTester;
 import org.sonar.api.config.internal.MapSettings;
+import org.sonar.api.notifications.AnalysisWarnings;
 import org.sonar.api.testfixtures.log.LogTesterJUnit5;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -55,7 +57,8 @@ class JacocoSensorTest {
   @RegisterExtension
   public LogTesterJUnit5 logTester = new LogTesterJUnit5();
 
-  private JacocoSensor sensor = new JacocoSensor(new ProjectCoverageContext());
+  private AnalysisWarnings analysisWarnings = mock(AnalysisWarnings.class);
+  private JacocoSensor sensor = new JacocoSensor(new ProjectCoverageContext(), analysisWarnings);
 
   @Test
   void describe_sensor() {
@@ -103,6 +106,8 @@ class JacocoSensorTest {
     assertThat(warningLogs)
             .hasSize(1);
     assertThat(warningLogs.get(0)).startsWith("No coverage report can be found with sonar.coverage.jacoco.xmlReportPaths='invalid.xml'.");
+    verify(analysisWarnings).addUnique(argThat(message ->
+            message.startsWith("No coverage report can be found with sonar.coverage.jacoco.xmlReportPaths='invalid.xml'.")));
   }
 
   @Test

--- a/src/test/java/org/sonar/plugins/jacoco/ReportPathsProviderTest.java
+++ b/src/test/java/org/sonar/plugins/jacoco/ReportPathsProviderTest.java
@@ -32,9 +32,11 @@ import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.event.Level;
 import org.sonar.api.batch.sensor.internal.SensorContextTester;
 import org.sonar.api.config.internal.MapSettings;
+import org.sonar.api.notifications.AnalysisWarnings;
 import org.sonar.api.testfixtures.log.LogTesterJUnit5;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -48,6 +50,7 @@ class ReportPathsProviderTest {
 
   private MapSettings settings;
   private SensorContextTester tester;
+  private AnalysisWarnings analysisWarnings;
   private ReportPathsProvider provider;
   private Path mavenPath1 = Paths.get("target", "site", "jacoco", "jacoco.xml");
   private Path mavenPath2 = Paths.get("target", "site", "jacoco-it", "jacoco.xml");
@@ -60,7 +63,8 @@ class ReportPathsProviderTest {
     settings = new MapSettings();
     tester = spy(SensorContextTester.create(baseDir));
     tester.setSettings(settings);
-    provider = new ReportPathsProvider(tester);
+    analysisWarnings = mock(AnalysisWarnings.class);
+    provider = new ReportPathsProvider(tester, analysisWarnings);
   }
 
   private void createMavenReport(Path relativePath) throws IOException {
@@ -113,6 +117,7 @@ class ReportPathsProviderTest {
     Path reportThatDoesNotExist = temp.resolve("report-that-does-not-exist.xml");
     settings.setProperty(ReportPathsProvider.AGGREGATE_REPORT_PATHS_PROPERTY_KEY, reportThatDoesNotExist.toString());
     assertThat(provider.getAggregateReportPaths()).isEmpty();
+    verify(analysisWarnings).addUnique(String.format("No coverage report found for pattern: '%s'", reportThatDoesNotExist));
     verify(tester, times(1)).addTelemetryProperty(TelemetryProperties.AGGREGATE_REPORT_PATH_PROPERTY_KEY_IS_SET, "true");
   }
 
@@ -190,8 +195,10 @@ class ReportPathsProviderTest {
     settings.setProperty(ReportPathsProvider.REPORT_PATHS_PROPERTY_KEY, "target/**/unknown.xml");
     assertThat(provider.getPaths()).isEmpty();
     assertThat(logTester.logs()).hasSize(1);
-    assertThat(logTester.logs(Level.WARN)).contains("No coverage report can be found with sonar.coverage.jacoco.xmlReportPaths='target/**/unknown.xml'." +
-      " Using default locations: target/site/jacoco/jacoco.xml,target/site/jacoco-it/jacoco.xml,build/reports/jacoco/test/jacocoTestReport.xml");
+    String expectedWarning = "No coverage report can be found with sonar.coverage.jacoco.xmlReportPaths='target/**/unknown.xml'." +
+      " Using default locations: target/site/jacoco/jacoco.xml,target/site/jacoco-it/jacoco.xml,build/reports/jacoco/test/jacocoTestReport.xml";
+    assertThat(logTester.logs(Level.WARN)).contains(expectedWarning);
+    verify(analysisWarnings).addUnique(expectedWarning);
   }
 
   @Test
@@ -222,8 +229,10 @@ class ReportPathsProviderTest {
 
     assertThat(paths).isEmpty();
     assertThat(logTester.logs()).hasSize(1);
-    assertThat(logTester.logs(Level.WARN)).containsExactly("No coverage report can be found with sonar.coverage.jacoco.xmlReportPaths='mypath1'." +
-      " Using default locations: target/site/jacoco/jacoco.xml,target/site/jacoco-it/jacoco.xml,build/reports/jacoco/test/jacocoTestReport.xml");
+    String expectedWarning = "No coverage report can be found with sonar.coverage.jacoco.xmlReportPaths='mypath1'." +
+      " Using default locations: target/site/jacoco/jacoco.xml,target/site/jacoco-it/jacoco.xml,build/reports/jacoco/test/jacocoTestReport.xml";
+    assertThat(logTester.logs(Level.WARN)).containsExactly(expectedWarning);
+    verify(analysisWarnings).addUnique(expectedWarning);
   }
 
   @Test
@@ -234,7 +243,9 @@ class ReportPathsProviderTest {
 
     assertThat(paths).isEmpty();
     assertThat(logTester.logs()).hasSize(3);
-    assertThat(logTester.logs(Level.WARN)).containsExactly("No coverage report can be found with sonar.coverage.jacoco.xmlReportPaths='mypath1,mypath2'. Using default locations: target/site/jacoco/jacoco.xml,target/site/jacoco-it/jacoco.xml,build/reports/jacoco/test/jacocoTestReport.xml");
+    String expectedWarning = "No coverage report can be found with sonar.coverage.jacoco.xmlReportPaths='mypath1,mypath2'. Using default locations: target/site/jacoco/jacoco.xml,target/site/jacoco-it/jacoco.xml,build/reports/jacoco/test/jacocoTestReport.xml";
+    assertThat(logTester.logs(Level.WARN)).containsExactly(expectedWarning);
+    verify(analysisWarnings).addUnique(expectedWarning);
     assertThat(logTester.logs(Level.INFO)).containsExactly(
       "Coverage report doesn't exist for pattern: 'mypath1'",
       "Coverage report doesn't exist for pattern: 'mypath2'");

--- a/src/test/java/org/sonar/plugins/jacoco/SensorUtilsTest.java
+++ b/src/test/java/org/sonar/plugins/jacoco/SensorUtilsTest.java
@@ -29,6 +29,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
 import org.sonar.api.batch.fs.InputFile;
+import org.sonar.api.notifications.AnalysisWarnings;
 import org.sonar.api.testfixtures.log.LogTesterJUnit5;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -75,7 +76,8 @@ class SensorUtilsTest {
 
     when(locator.getInputFile(null, "org/sonarlint/cli", "Stats.java")).thenReturn(inputFile);
 
-    SensorUtils.importReports(Arrays.asList(invalidFile, validFile), locator, importer, LOG);
+    AnalysisWarnings analysisWarnings = mock(AnalysisWarnings.class);
+    SensorUtils.importReports(Arrays.asList(invalidFile, validFile), locator, importer, LOG, analysisWarnings);
 
     String expectedErrorMessage = String.format(
             "Coverage report '%s' could not be read/imported. Error: java.lang.IllegalStateException: Invalid report: failed to parse integer from the attribute 'ci' for the sourcefile 'File.java' at line 6 column 61",
@@ -84,6 +86,7 @@ class SensorUtilsTest {
     assertThat(logTester.logs(Level.INFO)).contains("Importing 2 report(s). Turn your logs in debug mode in order to see the exhaustive list.");
 
     assertThat(logTester.logs(Level.ERROR)).contains(expectedErrorMessage);
+    verify(analysisWarnings).addUnique(expectedErrorMessage);
 
     verify(importer, times(1)).importCoverage(any(), eq(inputFile));
   }


### PR DESCRIPTION
----
## Summary by Gitar

- **Analysis warnings:**
  - Integrated `AnalysisWarnings` into `JacocoSensor`, `JacocoAggregateSensor`, and `ReportPathsProvider` to surface coverage issues.
  - Updated `SensorUtils` to push reporting errors and missing file path warnings to the SonarQube analysis dashboard.

<sub>This will update automatically on new commits.</sub>