### PR TITLE
JACOCO-143 Migrate tests from sonar-plugin-api-impl to scanner-engine test fixtures

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,8 @@ dependencies {
     testImplementation('org.mockito:mockito-core:5.23.0')
     testImplementation('org.assertj:assertj-core:3.27.7')
     testImplementation('org.sonarsource.api.plugin:sonar-plugin-api-test-fixtures:13.2.0.3137')
-    testImplementation('org.sonarsource.sonarqube:sonar-plugin-api-impl:26.6.0.123539')
+    testImplementation('org.sonarsource.scanner.engine:plugin-api-scanner-impl:13.4.0.3968')
+    testImplementation('org.sonarsource.scanner.engine:sensor-test-fixtures:13.4.0.3968')
 }
 
 test {

--- a/src/test/java/org/sonar/plugins/jacoco/FileLocatorTest.java
+++ b/src/test/java/org/sonar/plugins/jacoco/FileLocatorTest.java
@@ -19,6 +19,7 @@
  */
 package org.sonar.plugins.jacoco;
 
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestInputFileBuilder;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -28,7 +29,6 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.sonar.api.batch.fs.InputFile;
-import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;

--- a/src/test/java/org/sonar/plugins/jacoco/JacocoAggregateSensorTest.java
+++ b/src/test/java/org/sonar/plugins/jacoco/JacocoAggregateSensorTest.java
@@ -19,6 +19,7 @@
  */
 package org.sonar.plugins.jacoco;
 
+import com.sonarsource.scanner.engine.sensor.test.fixtures.SensorContextTester;
 import java.nio.file.Path;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -26,7 +27,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.event.Level;
 import org.sonar.api.batch.sensor.SensorDescriptor;
-import org.sonar.api.batch.sensor.internal.SensorContextTester;
 import org.sonar.api.notifications.AnalysisWarnings;
 import org.sonar.api.testfixtures.log.LogTesterJUnit5;
 

--- a/src/test/java/org/sonar/plugins/jacoco/JacocoSensorTest.java
+++ b/src/test/java/org/sonar/plugins/jacoco/JacocoSensorTest.java
@@ -19,6 +19,9 @@
  */
 package org.sonar.plugins.jacoco;
 
+import com.sonarsource.scanner.engine.sensor.test.fixtures.SensorContextTester;
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestFileSystem;
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestInputFileBuilder;
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -32,13 +35,10 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.rules.TemporaryFolder;
 import org.slf4j.event.Level;
 import org.sonar.api.batch.fs.InputFile;
-import org.sonar.api.batch.fs.internal.DefaultFileSystem;
-import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
 import org.sonar.api.batch.sensor.SensorDescriptor;
-import org.sonar.api.batch.sensor.internal.SensorContextTester;
-import org.sonar.api.config.internal.MapSettings;
 import org.sonar.api.notifications.AnalysisWarnings;
 import org.sonar.api.testfixtures.log.LogTesterJUnit5;
+import org.sonar.scanner.plugin.api.impl.config.MapSettings;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -75,7 +75,7 @@ class JacocoSensorTest {
       .setProperty("sonar.moduleKey", "module")
       .setProperty("sonar.projectBaseDir", temp.getRoot().getAbsolutePath());
     spiedContext.setSettings(settings);
-    DefaultFileSystem spiedFileSystem = spy(spiedContext.fileSystem());
+    TestFileSystem spiedFileSystem = spy(spiedContext.fileSystem());
     when(spiedContext.fileSystem()).thenReturn(spiedFileSystem);
     sensor.execute(spiedContext);
     // indexing all files in the filesystem is time consuming and should not be done if there no jacoco reports to import

--- a/src/test/java/org/sonar/plugins/jacoco/KotlinFileLocatorTest.java
+++ b/src/test/java/org/sonar/plugins/jacoco/KotlinFileLocatorTest.java
@@ -19,12 +19,11 @@
  */
 package org.sonar.plugins.jacoco;
 
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestInputFileBuilder;
 import java.nio.charset.Charset;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.sonar.api.batch.fs.InputFile;
-import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
-
-import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/src/test/java/org/sonar/plugins/jacoco/ModuleCoverageContextTest.java
+++ b/src/test/java/org/sonar/plugins/jacoco/ModuleCoverageContextTest.java
@@ -19,14 +19,14 @@
  */
 package org.sonar.plugins.jacoco;
 
+import com.sonarsource.scanner.engine.sensor.test.fixtures.SensorContextTester;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.sonar.api.batch.sensor.internal.SensorContextTester;
-import org.sonar.api.config.internal.MapSettings;
+import org.sonar.scanner.plugin.api.impl.config.MapSettings;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/src/test/java/org/sonar/plugins/jacoco/ReportImporterTest.java
+++ b/src/test/java/org/sonar/plugins/jacoco/ReportImporterTest.java
@@ -19,6 +19,8 @@
  */
 package org.sonar.plugins.jacoco;
 
+import com.sonarsource.scanner.engine.sensor.test.fixtures.SensorContextTester;
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestInputFileBuilder;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -28,8 +30,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.sonar.api.batch.fs.InputFile;
-import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
-import org.sonar.api.batch.sensor.internal.SensorContextTester;
 
 class ReportImporterTest {
   @TempDir

--- a/src/test/java/org/sonar/plugins/jacoco/ReportPathsProviderTest.java
+++ b/src/test/java/org/sonar/plugins/jacoco/ReportPathsProviderTest.java
@@ -19,6 +19,7 @@
  */
 package org.sonar.plugins.jacoco;
 
+import com.sonarsource.scanner.engine.sensor.test.fixtures.SensorContextTester;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -30,10 +31,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.event.Level;
-import org.sonar.api.batch.sensor.internal.SensorContextTester;
-import org.sonar.api.config.internal.MapSettings;
 import org.sonar.api.notifications.AnalysisWarnings;
 import org.sonar.api.testfixtures.log.LogTesterJUnit5;
+import org.sonar.scanner.plugin.api.impl.config.MapSettings;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;

--- a/src/test/java/org/sonar/plugins/jacoco/ReversePathTreeTest.java
+++ b/src/test/java/org/sonar/plugins/jacoco/ReversePathTreeTest.java
@@ -19,9 +19,9 @@
  */
 package org.sonar.plugins.jacoco;
 
+import com.sonarsource.scanner.engine.sensor.test.fixtures.TestInputFileBuilder;
 import org.junit.jupiter.api.Test;
 import org.sonar.api.batch.fs.InputFile;
-import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 

--- a/src/test/java/org/sonar/plugins/jacoco/WildcardPatternFileScannerTest.java
+++ b/src/test/java/org/sonar/plugins/jacoco/WildcardPatternFileScannerTest.java
@@ -19,12 +19,11 @@
  */
 package org.sonar.plugins.jacoco;
 
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
-
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.event.Level;
 import org.sonar.api.testfixtures.log.LogTesterJUnit5;
 


### PR DESCRIPTION
----
## Summary by Gitar

- **Test infrastructure migration:**
  - Replaced internal `sonar-plugin-api-impl` test dependencies with `sensor-test-fixtures` and `plugin-api-scanner-impl` in `build.gradle`.
  - Refactored test imports across multiple files to utilize the new `com.sonarsource.scanner.engine.sensor.test.fixtures` package.
  - Updated `JacocoSensorTest`, `ReportImporterTest`, and others to use `SensorContextTester` and `TestInputFileBuilder` from the new engine fixtures.

<sub>This will update automatically on new commits.</sub>