### PR TITLE
JACOCO-149 Do not notify automated release dry runs

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -58,7 +58,7 @@ jobs:
       sqs-integration: ${{ github.event.inputs.sqs-integration == 'true' }}
       branch: ${{ github.event.inputs.branch }}
       pm-email: "geoffray.adde@sonarsource.com"
-      slack-channel: "squad-corelang-releases"
+      slack-channel: ${{ github.event.inputs.dry-run != 'true' && 'squad-corelang-releases' || '' }}
       verbose: ${{ github.event.inputs.verbose == 'true' }}
       use-jira-sandbox: ${{ github.event.inputs.dry-run == 'true' }}
       is-draft-release: ${{ github.event.inputs.dry-run == 'true' }}


### PR DESCRIPTION
----
## Summary by Gitar

- **CI/CD configuration:**
  - Updated `automated-release.yml` to conditionally set `slack-channel` to empty during dry runs to prevent notifications.

<sub>This will update automatically on new commits.</sub>