### PR TITLE
CLP-211 Rely on shared Renovate configuration

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,19 +2,5 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>SonarSource/renovate-config:quality-corelang-squad"
-  ],
-  "ignorePaths": [
-    "its/src/test/resources/**"
-  ],
-  "packageRules": [
-    {
-      "matchManagers": [
-        "gradle"
-      ],
-      "matchPackageNames": [
-        "org.sonarsource.api.plugin:sonar-plugin-api*"
-      ],
-      "prHeader": "**Before updating the plugin-api version, make sure to check the [compatibility matrix](https://github.com/SonarSource/sonar-plugin-api?tab=readme-ov-file#compatibility) and stick to the lowest denominator.**"
-    }
   ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,5 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>SonarSource/renovate-config:quality-corelang-squad"
+  ],
+  "ignorePaths": [
+    "its/src/test/resources/**"
   ]
 }


### PR DESCRIPTION
Part of CLP-211

## Summary
- remove all repository-specific Renovate package rules
- preserve the existing Renovate ignore paths
- rely on the shared Core Languages preset for dependency update policy

## Validation
- parsed `.github/renovate.json` with `jq`
- verified that no local `packageRules` remain