### PR TITLE
JACOCO-173 Set Java 21 as the required version in Unified Dogfooding workflow

### DIFF
--- a/.github/workflows/unified-dogfooding.yml
+++ b/.github/workflows/unified-dogfooding.yml
@@ -15,6 +15,11 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: true
+      - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
+        with:
+          version: 2026.7.7
+      - name: Select Java 21
+        run: mise use java@21
       - uses: SonarSource/ci-github-actions/build-gradle@v1
         with:
           run-shadow-scans: true


### PR DESCRIPTION
Scanner-engine 13.7.0.4455+ test artifacts require JVM 21, but this workflow ran Gradle on the default JDK 17, breaking testCompileClasspath resolution. Mirrors the mise/Java 21 setup already used in build.yml.