### PR TITLE
JACOCO-179 Update the minimum Java version to 21

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
       contents: write  # Required for repository access and tagging
     env:
       BUILD_NUMBER: ${{ needs.build.outputs.build-number }}
-      SQ_VERSION: 'LATEST_RELEASE[2025.4]'
+      SQ_VERSION: 'LATEST_RELEASE[2026.1]'
     steps:
       - name: Config Git
         run: git config --global core.autocrlf input
@@ -93,8 +93,10 @@ jobs:
       fail-fast: false
       matrix:
         sq-version:
-          - "LATEST_RELEASE[2025.1]"
-          - "LATEST_RELEASE[2025.4]"
+          # The plugin is compiled for Java 21, so it can only run on SonarQube versions that provision a Java 21 JRE to the scanner. 2026.1 is the oldest one, 2025.x provisions
+          # Java 17.
+          - "LATEST_RELEASE[2026.1]"
+          - "LATEST_RELEASE"
           - "DEV"
         is_nightly:
           - ${{ github.event_name == 'schedule' }}

--- a/build.gradle
+++ b/build.gradle
@@ -27,8 +27,8 @@ if (version.endsWith('-SNAPSHOT') && ext.buildNumber != null) {
 }
 
 compileJava {
-    // Setting the compatibility to Java 11 (https://docs.gradle.org/7.6.3/userguide/building_java_projects.html#sec:java_cross_compilation)
-    options.release = 11
+    // Setting the compatibility to Java 21 (https://docs.gradle.org/7.6.3/userguide/building_java_projects.html#sec:java_cross_compilation)
+    options.release = 21
 }
 
 tasks.withType(Javadoc) {
@@ -101,6 +101,7 @@ jar {
         attributes(
                 'Build-Time': buildDate,
                 'Implementation-Build': 'git rev-parse HEAD'.execute().text.trim(),
+                'Jre-Min-Version': '21',
                 'Plugin-BuildDate': buildDate,
                 'Plugin-ChildFirstClassLoader': 'false',
                 'Plugin-Class': 'org.sonar.plugins.jacoco.JacocoPlugin',

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ if (version.endsWith('-SNAPSHOT') && ext.buildNumber != null) {
 }
 
 compileJava {
-    // Setting the compatibility to Java 21 (https://docs.gradle.org/7.6.3/userguide/building_java_projects.html#sec:java_cross_compilation)
+    // Setting the compatibility to Java 21 (https://docs.gradle.org/9.7.1/userguide/building_java_projects.html#sec:java_cross_compilation)
     options.release = 21
 }
 

--- a/its/src/test/java/org/sonar/plugins/jacoco/its/JacocoTest.java
+++ b/its/src/test/java/org/sonar/plugins/jacoco/its/JacocoTest.java
@@ -68,7 +68,8 @@ class JacocoTest {
     }
     builder.addPlugin(pluginLocation);
     try {
-      // The versions of these 2 plugins were chosen because they have shipped with SQS 2025.1 and greater
+      // These 2 plugins are pinned to keep the coverage assertions below stable. They are compatible with every SonarQube version of the QA matrix, which starts at SQS 2026.1
+      // because this plugin is compiled for Java 21 and older servers provision a Java 17 JRE to the scanner.
       builder.addPlugin(URLLocation.create(new URL("https://binaries.sonarsource.com/Distribution/sonar-java-plugin/sonar-java-plugin-8.9.3.40136.jar")));
       builder.addPlugin(URLLocation.create(new URL("https://binaries.sonarsource.com/Distribution/sonar-kotlin-plugin/sonar-kotlin-plugin-2.22.1.6674.jar")));
     } catch (MalformedURLException e) {

--- a/its/src/test/java/org/sonar/plugins/jacoco/its/JacocoTest.java
+++ b/its/src/test/java/org/sonar/plugins/jacoco/its/JacocoTest.java
@@ -68,8 +68,6 @@ class JacocoTest {
     }
     builder.addPlugin(pluginLocation);
     try {
-      // These 2 plugins are pinned to keep the coverage assertions below stable. They are compatible with every SonarQube version of the QA matrix, which starts at SQS 2026.1
-      // because this plugin is compiled for Java 21 and older servers provision a Java 17 JRE to the scanner.
       builder.addPlugin(URLLocation.create(new URL("https://binaries.sonarsource.com/Distribution/sonar-java-plugin/sonar-java-plugin-8.9.3.40136.jar")));
       builder.addPlugin(URLLocation.create(new URL("https://binaries.sonarsource.com/Distribution/sonar-kotlin-plugin/sonar-kotlin-plugin-2.22.1.6674.jar")));
     } catch (MalformedURLException e) {


### PR DESCRIPTION
----
## Summary by Gitar

- **Java Version Upgrade:**
    - Updated minimum Java version to `21` in `build.gradle` and set `Jre-Min-Version` manifest attribute
- **CI/CD Updates:**
    - Updated SonarQube versions in `build.yml` workflow matrix to provision Java 21 JRE

<sub>This will update automatically on new commits.</sub>