### PR TITLE
JACOCO-186 Remove redundant logging dependency handling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,6 @@ dependencies {
     testImplementation('org.junit.jupiter:junit-jupiter-migrationsupport')
     testRuntimeOnly('org.junit.platform:junit-platform-launcher')
 
-    testImplementation('ch.qos.logback:logback-classic:1.5.38')
     testImplementation('org.mockito:mockito-core:5.23.0')
     testImplementation('org.assertj:assertj-core:3.27.7')
     testImplementation('org.sonarsource.api.plugin:sonar-plugin-api-test-fixtures:14.0.0.4498')


### PR DESCRIPTION
Part of

## Summary

- Remove redundant SLF4J and Logback dependency declarations, constraints, and update exceptions.
- Rely on Sonar Plugin API v14 and its test fixtures to provide SLF4J 2.0.18 and Logback 1.6.3.

