### PR TITLE
BUILD-12310 Migrate eligible jobs to self-hosted runners

### DIFF
--- a/.github/workflows/ToggleLockBranch.yml
+++ b/.github/workflows/ToggleLockBranch.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   ToggleLockBranch_job:
     name: Toggle lock branch
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-xs
     permissions:
       id-token: write
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-xs
     name: Build
     permissions:
       id-token: write  # Required for Vault OIDC authentication
@@ -43,7 +43,7 @@ jobs:
   build-qa-windows:
     name: Build and QA Windows
     needs: build
-    runs-on: github-windows-latest-m
+    runs-on: warp-custom-windows-2022-m
     permissions:
       id-token: write  # Required for Vault OIDC authentication
       contents: write  # Required for repository access and tagging
@@ -85,7 +85,7 @@ jobs:
   qa:
     needs: [build]
     if: ${{ needs.build.outputs.deployed }}
-    runs-on: github-ubuntu-latest-m
+    runs-on: sonar-m
     permissions:
       id-token: write
       contents: read
@@ -147,7 +147,7 @@ jobs:
   promote:
     needs: [build, build-qa-windows, qa]
     if: ${{ needs.build.outputs.deployed }}
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-xs
     name: Promote
     permissions:
       id-token: write

--- a/.github/workflows/mark-prs-stale.yml
+++ b/.github/workflows/mark-prs-stale.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   stale:
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-xs
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   cleanup:
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-xs
     permissions:
       actions: write
     steps:

--- a/.github/workflows/releasability.yaml
+++ b/.github/workflows/releasability.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   update_releasability_status:
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-xs
     name: Releasability status
     permissions:
       id-token: write

--- a/.github/workflows/unified-dogfooding.yml
+++ b/.github/workflows/unified-dogfooding.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   unified-platform-dogfooding:
-    runs-on: github-ubuntu-latest-m
+    runs-on: sonar-m
     name: Unified Platform Dogfooding
     permissions:
       id-token: write


### PR DESCRIPTION
BUILD-12310

## Purpose
Self-hosted runners should be used in all cases except approved use cases where self-hosted runners do not work. They are more cost-efficient and faster than GitHub-hosted runners.

This PR migrates the remaining eligible Linux and Windows workflow jobs to SonarSource self-hosted runner labels, using right-sized runners for automation, build, QA, promotion, and dogfooding jobs.

No hosted-runner exception is retained by this change. The owning squad should perform final workflow validation before merging.

## Validation
- `git diff --check`
- Scoped `actionlint`; passed after excluding expected unknown-label diagnostics for SonarSource custom runner labels and unrelated pre-existing shellcheck findings.

## Tracking
- Subtask: https://sonarsource.atlassian.net/browse/BUILD-12310
- Parent: https://sonarsource.atlassian.net/browse/BUILD-12470
- Migration initiative: https://sonarsource.atlassian.net/browse/BUILD-12260

Owning squad: please take over final workflow validation and merge this PR. Let us know if you encounter any issues.